### PR TITLE
fix: properly replace __BKT_SDK_VERSION__ in build output

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -3,11 +3,6 @@ import packageJson from './package.json'
 
 export default defineBuildConfig({
   replace: {
-    __BKT_SDK_VERSION__: packageJson.version,
-  },
-  rollup: {
-    replace: {
-      delimiters: ['\\${', '}'],
-    },
+    __BKT_SDK_VERSION__: JSON.stringify(packageJson.version),
   },
 })


### PR DESCRIPTION
## Overview

Fixes version placeholder replacement in build output by stringifying packageJson.version and removing unnecessary rollup delimiter configuration.

Before: __BKT_SDK_VERSION__ was not replaced
After: Correctly replaced with "0.0.1"

<img width="1494" height="130" alt="CleanShot 2025-11-18 at 20 56 48@2x" src="https://github.com/user-attachments/assets/58aed984-b5b5-4dd4-b679-c52b23e443a3" />
