### PR TITLE
test(e2e): ensure SDK_VERSION is defined

### DIFF
--- a/e2e/evaluate.test.ts
+++ b/e2e/evaluate.test.ts
@@ -47,8 +47,11 @@ suite('BucketeerProvider - evaluation', () => {
 
     const client = OpenFeature.getClient()
     expect(client.metadata.providerMetadata.name).equal('Bucketeer Provider')
-    expect(client.metadata.providerMetadata.version).equal(SDK_VERSION)
     expect(client.providerStatus).equal(ProviderStatus.READY)
+    // Check that SDK_VERSION is defined
+    expect(SDK_VERSION).not.toBeUndefined()
+    expect(SDK_VERSION).toMatch(/^\d+\.\d+\.\d+(-.+)?$/)
+    expect(client.metadata.providerMetadata.version).equal(SDK_VERSION)
   })
 
   suite('boolean evaluation', () => {

--- a/vitest-e2e.config.ts
+++ b/vitest-e2e.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig } from 'vitest/config'
-import packageJson from './package.json'
 
 export default defineConfig({
-  define: {
-    __BKT_SDK_VERSION__: JSON.stringify(packageJson.version),
-  },
   test: {
     setupFiles: [],
     environment: 'happy-dom',


### PR DESCRIPTION
Related to: https://github.com/bucketeer-io/openfeature-js-client-sdk/pull/8
The e2e tests didn’t catch the error because the e2e setup was replacing VERSION in the build output when it shouldn’t.

### Changes
- Added e2e checks to ensure SDK_VERSION is defined and follows semantic versioning.
- Removed version replacement in vitest-e2e.config.ts to ensure the build output remains untouched.