### PR TITLE
build(deps): update @bucketeer/js-client-sdk peer dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,7 @@
     "@openfeature/web-sdk": ">=1.4.0 <2.0.0",
     "@bucketeer/js-client-sdk": ">=2.4.0 <3.0.0"
   },
-  "dependencies": {
-    "typescript": "^5.8.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/jsdom": "21.1.7",
     "@types/node": "22.13.9",
@@ -61,14 +59,11 @@
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-prettier": "5.2.3",
     "happy-dom": "17.1.9",
-    "install": "^0.13.0",
-    "jiti": "2.4.2",
-    "msw": "2.7.3",
-    "npm": "^11.4.1",
     "prettier": "3.5.3",
     "typescript-eslint": "8.26.0",
     "unbuild": "3.5.0",
     "vitest": "2.1.8",
-    "webdriverio": "9.5.1"
+    "webdriverio": "9.5.1",
+    "typescript": "^5.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@openfeature/web-sdk':
         specifier: '>=1.4.0 <2.0.0'
         version: 1.5.0(@openfeature/core@1.7.2)
-      typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
     devDependencies:
       '@types/jsdom':
         specifier: 21.1.7
@@ -51,21 +48,12 @@ importers:
       happy-dom:
         specifier: 17.1.9
         version: 17.1.9
-      install:
-        specifier: ^0.13.0
-        version: 0.13.0
-      jiti:
-        specifier: 2.4.2
-        version: 2.4.2
-      msw:
-        specifier: 2.7.3
-        version: 2.7.3(@types/node@22.13.9)(typescript@5.8.3)
-      npm:
-        specifier: ^11.4.1
-        version: 11.4.1
       prettier:
         specifier: 3.5.3
         version: 3.5.3
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
       typescript-eslint:
         specifier: 8.26.0
         version: 8.26.0(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.3)
@@ -2085,10 +2073,6 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  install@0.13.0:
-    resolution: {integrity: sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==}
-    engines: {node: '>= 0.10'}
-
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -2450,78 +2434,6 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
-
-  npm@11.4.1:
-    resolution: {integrity: sha512-/O5DiEFmtvnF0EU1+5VlDpcItpSKH3l+3fQOl3hkZ3ilGN+jJlGxxi/zb0rEK+zxd8pGyifVPyS1ORkMjZGAKw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-    hasBin: true
-    bundledDependencies:
-      - '@isaacs/string-locale-compare'
-      - '@npmcli/arborist'
-      - '@npmcli/config'
-      - '@npmcli/fs'
-      - '@npmcli/map-workspaces'
-      - '@npmcli/package-json'
-      - '@npmcli/promise-spawn'
-      - '@npmcli/redact'
-      - '@npmcli/run-script'
-      - '@sigstore/tuf'
-      - abbrev
-      - archy
-      - cacache
-      - chalk
-      - ci-info
-      - cli-columns
-      - fastest-levenshtein
-      - fs-minipass
-      - glob
-      - graceful-fs
-      - hosted-git-info
-      - ini
-      - init-package-json
-      - is-cidr
-      - json-parse-even-better-errors
-      - libnpmaccess
-      - libnpmdiff
-      - libnpmexec
-      - libnpmfund
-      - libnpmorg
-      - libnpmpack
-      - libnpmpublish
-      - libnpmsearch
-      - libnpmteam
-      - libnpmversion
-      - make-fetch-happen
-      - minimatch
-      - minipass
-      - minipass-pipeline
-      - ms
-      - node-gyp
-      - nopt
-      - normalize-package-data
-      - npm-audit-report
-      - npm-install-checks
-      - npm-package-arg
-      - npm-pick-manifest
-      - npm-profile
-      - npm-registry-fetch
-      - npm-user-validate
-      - p-map
-      - pacote
-      - parse-conflict-json
-      - proc-log
-      - qrcode-terminal
-      - read
-      - semver
-      - spdx-expression-parse
-      - ssri
-      - supports-color
-      - tar
-      - text-table
-      - tiny-relative-date
-      - treeverse
-      - validate-npm-package-name
-      - which
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -5537,8 +5449,6 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  install@0.13.0: {}
-
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -5877,8 +5787,6 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
-
-  npm@11.4.1: {}
 
   nth-check@2.1.1:
     dependencies:


### PR DESCRIPTION
This pull request updates dependency versions and cleans up unused packages in both `package.json` and `pnpm-lock.yaml`. The main focus is upgrading the `@bucketeer/js-client-sdk` to a newer version range and removing several unused development dependencies, resulting in a leaner and more up-to-date dependency tree.

**Dependency upgrades:**

* Upgraded `@bucketeer/js-client-sdk` peer dependency in `package.json` from version `2.2.5` to the range `>=2.4.0 <3.0.0`, and updated the corresponding lockfile entry to `2.4.0`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L47-R49) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-L19) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR106-R108) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3493-R3496)

**Dependency cleanup:**

* Removed unused devDependencies: `install`, `jiti`, `msw`, and `npm` from `package.json` and `pnpm-lock.yaml`, reducing package bloat. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L64-R67) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL54-R56) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2082-L2085) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2448-L2519) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5526-L5527) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5867-L5868)

**Other dependency maintenance:**

* Moved `typescript` from dependencies to devDependencies in `package.json` and updated its lockfile entry, ensuring it's only used for development. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L47-R49) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L64-R67) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-L19) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL54-R56)

* Added new dependency `async-mutex@0.5.0` as a transitive dependency of the upgraded `@bucketeer/js-client-sdk@2.4.0`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1251-R1253) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3493-R3496) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4436-R4439)Changed the peer dependency for @bucketeer/js-client-sdk in package.json to '>=2.4.0 <3.0.0' to support newer versions. Updated pnpm-lock.yaml to reflect the new version and its dependencies.