### PR TITLE
fix: react native provider init error when using defineBKTConfig

### DIFF
--- a/docs/react-native.md
+++ b/docs/react-native.md
@@ -58,13 +58,13 @@ Please use the [OpenFeature React SDK](https://openfeature.dev/docs/reference/sd
 
 ### Configuration & Initialization
 
-Use `defineBKTConfig` to create your configuration and set up the `OpenFeatureProvider`. Make sure to use the global `fetch` API.
+Use `defineBKTConfigForReactNative` to create your configuration and set up the `OpenFeatureProvider`. Make sure to use the global `fetch` API.
 
 ```typescript
 import { OpenFeatureProvider, OpenFeature } from '@openfeature/react-sdk';
-import { defineBKTConfig, BucketeerReactNativeProvider } from '@bucketeer/openfeature-js-client-sdk';
+import { defineBKTConfigForReactNative, BucketeerReactNativeProvider } from '@bucketeer/openfeature-js-client-sdk';
 
-const config = defineBKTConfig({
+const config = defineBKTConfigForReactNative({
   apiEndpoint: 'BUCKETEER_API_ENDPOINT',
   apiKey: 'BUCKETEER_API_KEY',
   featureTag: 'FEATURE_TAG',
@@ -94,8 +94,16 @@ function App() {
 
 See our [documentation](https://docs.bucketeer.io/sdk/client-side/javascript#configuring-client) for more SDK configuration.
 
-> [!IMPORTANT]
-> In the React Native environment, any `idGenerator` or `storageFactory` provided in the configuration will be **ignored**. The `BucketeerReactNativeProvider` automatically provides specialized React Native implementations for these during initialization.
+> [!NOTE]
+> Use `defineBKTConfigForReactNative` for the standard setup — you do not need to provide
+> an `idGenerator`. The `BucketeerReactNativeProvider` automatically loads and injects
+> the correct React Native implementation (`react-native-uuid`) during initialization.
+
+> [!NOTE]
+> If you need to use `defineBKTConfig` directly (for example when using the native SDK
+> alongside the OpenFeature provider), you must provide your own `idGenerator` implementation.
+> In this case the provider will still replace it with its internal `react-native-uuid` generator
+> during initialization — `idGenerator` is always managed internally by `BucketeerReactNativeProvider`.
 
 
 ### Evaluate a feature flag

--- a/examples/react_native/App.tsx
+++ b/examples/react_native/App.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable semi */
 import { OpenFeature, OpenFeatureProvider } from '@openfeature/react-sdk';
 import { StyleSheet, Text, View } from 'react-native';
-import { BucketeerReactNativeProvider, defineBKTConfig } from '@bucketeer/openfeature-js-client-sdk';
+import { BucketeerReactNativeProvider, defineBKTConfigForReactNative } from '@bucketeer/openfeature-js-client-sdk';
 import React, { Suspense } from 'react';
 
 const API_ENDPOINT =
@@ -9,7 +9,7 @@ const API_ENDPOINT =
 const API_KEY = process.env.EXPO_PUBLIC_BKT_API_KEY || 'api-key';
 const FEATURE_TAG = process.env.EXPO_PUBLIC_FEATURE_TAG || 'feature-tag';
 
-const config = defineBKTConfig({
+const config = defineBKTConfigForReactNative({
   apiEndpoint: API_ENDPOINT,
   apiKey: API_KEY,
   featureTag: FEATURE_TAG,

--- a/src/internal/react_native/BucketeerReactNativeProvider.ts
+++ b/src/internal/react_native/BucketeerReactNativeProvider.ts
@@ -48,9 +48,11 @@ class BucketeerReactNativeProvider extends BucketeerProvider {
       throw new ProviderFatalError('react-native-uuid is not available. Please add it as a dependency.')
     }
 
-    // This provider is designed to provide React Native specific implementations.
-    // User-provided storageFactory or idGenerator in the config are ignored to ensure
-    // the correct environment-specific behavior is maintained.
+    // idGenerator is always managed internally by this provider.
+    // The react-native-uuid implementation is injected here, replacing the placeholder
+    // set by defineBKTConfigForReactNative. Any idGenerator value in the incoming config
+    // is intentionally ignored — it is an internal-only concern of the provider.
+    // storageFactory is also always replaced with the React Native AsyncStorage implementation.
     this.config = defineBKTConfig({
       ...this.config,
       storageFactory: storageFactory,

--- a/src/internal/react_native/defineBKTConfigForReactNative.ts
+++ b/src/internal/react_native/defineBKTConfigForReactNative.ts
@@ -1,0 +1,51 @@
+import { defineBKTConfig, RawBKTConfig, BKTConfig } from '@bucketeer/js-client-sdk'
+
+// IdGenerator is an internal type in @bucketeer/js-client-sdk and is not part of its public API.
+// We derive it here for internal use only — this type is never exposed to users of this package.
+type IdGenerator = NonNullable<RawBKTConfig['idGenerator']>
+
+/**
+ * A placeholder IdGenerator injected by defineBKTConfigForReactNative.
+ *
+ * WHY THIS EXISTS:
+ * The native SDK's defineBKTConfig (from main.native.ts) enforces that idGenerator
+ * is present via a runtime guard — because the native SDK requires it when calling
+ * initializeBKTClient directly.
+ *
+ * In the OpenFeature adapter, however, the real idGenerator (react-native-uuid) must be
+ * loaded via an async dynamic import inside BucketeerReactNativeProvider.initialize().
+ * This is necessary because react-native-uuid may not be installed, and we need a safe,
+ * non-crashing import path to detect its absence and throw a ProviderFatalError instead.
+ *
+ * LIFECYCLE:
+ *   1. defineBKTConfigForReactNative()             → injects this placeholder to pass the guard
+ *   2. BucketeerReactNativeProvider.initialize()   → loads the real generator and replaces it
+ *   3. initializeBKTClient()                       → called AFTER step 2, real generator is used
+ *
+ * This placeholder is NEVER called to generate a real ID. If it is, it means
+ * initialize() was skipped — the error below will surface that misconfiguration clearly.
+ */
+export const REACT_NATIVE_PLACEHOLDER_ID_GENERATOR: IdGenerator = {
+  newId: () => {
+    throw new Error(
+      '[Bucketeer] defineBKTConfigForReactNative placeholder idGenerator was called. ' +
+        'This means BucketeerReactNativeProvider.initialize() was not called before the client was used. ' +
+        'Ensure OpenFeature.setProvider() is called before using the client.',
+    )
+  },
+}
+
+/**
+ * Creates a BKTConfig for use with BucketeerReactNativeProvider.
+ *
+ * Use this instead of the native SDK's defineBKTConfig when using BucketeerReactNativeProvider.
+ * You do not need to provide an idGenerator — it is always managed internally by the provider,
+ * which automatically loads and injects the correct React Native implementation (react-native-uuid)
+ * during initialization. Any idGenerator provided in the config will be ignored.
+ */
+export const defineBKTConfigForReactNative = (config: RawBKTConfig): BKTConfig => {
+  return defineBKTConfig({
+    ...config,
+    idGenerator: REACT_NATIVE_PLACEHOLDER_ID_GENERATOR,
+  })
+}

--- a/src/main.react-native.ts
+++ b/src/main.react-native.ts
@@ -1,6 +1,8 @@
 import { BucketeerReactNativeProvider } from './internal/react_native/BucketeerReactNativeProvider'
+import { defineBKTConfigForReactNative } from './internal/react_native/defineBKTConfigForReactNative'
 
 export { BucketeerReactNativeProvider }
+export { defineBKTConfigForReactNative }
 export { SDK_VERSION } from './version'
 
 // Re-exporting the entire public API of @bucketeer/js-client-sdk is intentional.

--- a/test/internal/defineBKTConfigForReactNative.test.ts
+++ b/test/internal/defineBKTConfigForReactNative.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import {
+  defineBKTConfigForReactNative,
+  REACT_NATIVE_PLACEHOLDER_ID_GENERATOR,
+} from '../../src/internal/react_native/defineBKTConfigForReactNative'
+
+const validBaseConfig = {
+  apiKey: 'test-api-key',
+  apiEndpoint: 'http://test-endpoint',
+  appVersion: '1.0.0',
+  fetch: globalThis.fetch ?? (() => Promise.resolve(new Response())),
+}
+
+describe('defineBKTConfigForReactNative', () => {
+  describe('idGenerator handling', () => {
+    it('should not require idGenerator in the input config', () => {
+      // The native SDK's defineBKTConfig would throw here if called directly.
+      // defineBKTConfigForReactNative injects a placeholder to satisfy the guard.
+      expect(() => defineBKTConfigForReactNative(validBaseConfig)).not.toThrow()
+    })
+
+    it('should always inject the placeholder idGenerator into the returned config', () => {
+      const config = defineBKTConfigForReactNative(validBaseConfig)
+      expect(config.idGenerator).toBe(REACT_NATIVE_PLACEHOLDER_ID_GENERATOR)
+    })
+
+    it('should override any user-provided idGenerator with the placeholder', () => {
+      // idGenerator is always managed internally — user-provided values are
+      // always overridden by the placeholder, and later by the provider's initialize().
+      const customGenerator = { newId: () => 'custom-id' }
+      const config = defineBKTConfigForReactNative({
+        ...validBaseConfig,
+        idGenerator: customGenerator,
+      })
+      expect(config.idGenerator).toBe(REACT_NATIVE_PLACEHOLDER_ID_GENERATOR)
+      expect(config.idGenerator).not.toBe(customGenerator)
+    })
+  })
+
+  describe('REACT_NATIVE_PLACEHOLDER_ID_GENERATOR', () => {
+    it('should throw a descriptive error if newId() is called before initialize()', () => {
+      expect(() => REACT_NATIVE_PLACEHOLDER_ID_GENERATOR.newId()).toThrowError(
+        /defineBKTConfigForReactNative placeholder idGenerator was called/,
+      )
+    })
+
+    it('error message should mention that setProvider must be called', () => {
+      expect(() => REACT_NATIVE_PLACEHOLDER_ID_GENERATOR.newId()).toThrowError(
+        /OpenFeature\.setProvider\(\) is called/,
+      )
+    })
+  })
+
+  describe('required field validation', () => {
+    it('should throw when apiKey is missing', () => {
+      expect(() =>
+        defineBKTConfigForReactNative({ ...validBaseConfig, apiKey: '' }),
+      ).toThrowError(/apiKey is required/)
+    })
+
+    it('should throw when apiEndpoint is missing', () => {
+      expect(() =>
+        defineBKTConfigForReactNative({ ...validBaseConfig, apiEndpoint: '' }),
+      ).toThrowError(/apiEndpoint is required/)
+    })
+
+    it('should throw when apiEndpoint is not a valid URL', () => {
+      expect(() =>
+        defineBKTConfigForReactNative({ ...validBaseConfig, apiEndpoint: 'not-a-url' }),
+      ).toThrowError(/apiEndpoint is invalid/)
+    })
+
+    it('should throw when appVersion is missing', () => {
+      expect(() =>
+        defineBKTConfigForReactNative({ ...validBaseConfig, appVersion: '' }),
+      ).toThrowError(/appVersion is required/)
+    })
+  })
+
+  describe('config field pass-through', () => {
+    it('should correctly pass through all provided config fields', () => {
+      const config = defineBKTConfigForReactNative({
+        ...validBaseConfig,
+        featureTag: 'my-tag',
+        eventsMaxQueueSize: 200,
+        appVersion: '2.0.0',
+        userAgent: 'custom-agent',
+      })
+
+      expect(config.apiKey).toBe('test-api-key')
+      expect(config.apiEndpoint).toBe('http://test-endpoint')
+      expect(config.featureTag).toBe('my-tag')
+      expect(config.eventsMaxQueueSize).toBe(200)
+      expect(config.appVersion).toBe('2.0.0')
+      expect(config.userAgent).toBe('custom-agent')
+    })
+
+    it('should apply SDK defaults for omitted optional fields', () => {
+      const config = defineBKTConfigForReactNative(validBaseConfig)
+
+      expect(config.featureTag).toBe('')
+      expect(config.eventsMaxQueueSize).toBe(50)
+      // pollingInterval below minimum is clamped to 600000ms
+      expect(config.pollingInterval).toBe(600000)
+      // eventsFlushInterval below minimum is clamped to 10000ms
+      expect(config.eventsFlushInterval).toBe(10000)
+    })
+  })
+})

--- a/test/internal/integration/provider.react.native.integration.spec.ts
+++ b/test/internal/integration/provider.react.native.integration.spec.ts
@@ -1,0 +1,144 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { defineBKTConfig } from '@bucketeer/js-client-sdk'
+import { ProviderFatalError } from '@openfeature/web-sdk'
+import { BucketeerReactNativeProvider } from '../../../src/internal/react_native/BucketeerReactNativeProvider'
+import { defineBKTConfigForReactNative } from '../../../src/internal/react_native/defineBKTConfigForReactNative'
+
+/**
+ * INTEGRATION TESTS for BucketeerReactNativeProvider config paths
+ *
+ * Purpose: Verify end-to-end initialization behavior for both the standard path
+ * (defineBKTConfigForReactNative) and the advanced path (defineBKTConfig with custom idGenerator),
+ * using the real react-native-uuid module without mocking IdGeneratorFactory.
+ *
+ * Why this works without mocks:
+ * 1. react-native-uuid is a pure JavaScript module that works in any JS environment.
+ * 2. Vitest resolves it from devDependencies, same as a real React Native app would.
+ * 3. @bucketeer/js-client-sdk initializeBKTClient is mocked only to prevent real network calls.
+ *
+ * These tests live in test/internal/integration/ so they run in the browser/DOM
+ * Vitest environment and are excluded from the Node test run, consistent with the
+ * existing integration test convention.
+ */
+
+vi.mock('@bucketeer/js-client-sdk', async () => {
+  const actual = await vi.importActual('@bucketeer/js-client-sdk')
+  return {
+    ...actual,
+    initializeBKTClient: vi.fn().mockResolvedValue(undefined),
+    getBKTClient: vi.fn(),
+    destroyBKTClient: vi.fn(),
+  }
+})
+
+const validRawConfig = {
+  apiKey: 'test-api-key',
+  apiEndpoint: 'http://test-endpoint',
+  appVersion: '1.0.0',
+  fetch: globalThis.fetch ?? (() => Promise.resolve(new Response())),
+}
+
+const mockContext = {
+  targetingKey: 'test-user',
+}
+
+describe('BucketeerReactNativeProvider — config path integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  describe('standard path: defineBKTConfigForReactNative', () => {
+    it('should initialize successfully with real react-native-uuid as idGenerator', async () => {
+      const config = defineBKTConfigForReactNative(validRawConfig)
+      const provider = new BucketeerReactNativeProvider(config)
+
+      // Should not throw — provider loads real react-native-uuid during initialize()
+      await expect(provider.initialize?.(mockContext)).resolves.not.toThrow()
+    })
+
+    it('should inject a real UUID-generating idGenerator after initialize()', async () => {
+      const { initializeBKTClient } = await import('@bucketeer/js-client-sdk')
+
+      const config = defineBKTConfigForReactNative(validRawConfig)
+      const provider = new BucketeerReactNativeProvider(config)
+      await provider.initialize?.(mockContext)
+
+      const actualConfig = vi.mocked(initializeBKTClient).mock.calls[0][0]
+      expect(actualConfig.idGenerator).toBeDefined()
+      expect(typeof actualConfig.idGenerator?.newId).toBe('function')
+
+      const id = actualConfig.idGenerator?.newId()
+      expect(typeof id).toBe('string')
+      expect(id!.length).toBeGreaterThan(0)
+
+      // Should look like a valid UUID v4
+      const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      expect(id).toMatch(uuidV4Regex)
+    })
+
+    it('should throw ProviderFatalError when react-native-uuid is not available', async () => {
+      // Simulate missing react-native-uuid by stubbing the factory to return undefined
+      vi.doMock('../../../src/internal/react_native/IdGeneratorFactory', () => ({
+        createReactNativeIdGenerator: vi.fn().mockResolvedValue(undefined),
+      }))
+      vi.resetModules()
+
+      const { BucketeerReactNativeProvider: FreshProvider } = await import(
+        '../../../src/internal/react_native/BucketeerReactNativeProvider'
+      )
+      const { defineBKTConfigForReactNative: freshDefine } = await import(
+        '../../../src/internal/react_native/defineBKTConfigForReactNative'
+      )
+
+      const config = freshDefine(validRawConfig)
+      const provider = new FreshProvider(config)
+
+      await expect(provider.initialize?.(mockContext)).rejects.toThrow(ProviderFatalError)
+
+      vi.doUnmock('../../../src/internal/react_native/IdGeneratorFactory')
+    })
+  })
+
+  describe('advanced path: defineBKTConfig with custom idGenerator', () => {
+    it('should NOT throw at config time in non-RN environments but WOULD throw in React Native bundles', () => {
+      // In a React Native bundle, @bucketeer/js-client-sdk resolves to main.native.ts
+      // which enforces idGenerator via a runtime guard. In the Node/browser test environment,
+      // it resolves to the base entry which does NOT require idGenerator.
+      // defineBKTConfigForReactNative exists to protect users who call it in React Native
+      // from hitting this guard — it injects the placeholder so the guard is always satisfied.
+      //
+      // This test documents that without defineBKTConfigForReactNative, the user would need
+      // to provide their own idGenerator when using defineBKTConfig in a React Native app.
+      expect(() => defineBKTConfig(validRawConfig)).not.toThrow()
+    })
+
+    it('should initialize successfully when a custom idGenerator is provided to defineBKTConfig', async () => {
+      const { initializeBKTClient } = await import('@bucketeer/js-client-sdk')
+
+      const customIdCount = { count: 0 }
+      const customGenerator = {
+        newId: () => `custom-id-${++customIdCount.count}`,
+      }
+
+      const config = defineBKTConfig({
+        ...validRawConfig,
+        idGenerator: customGenerator,
+      })
+      const provider = new BucketeerReactNativeProvider(config)
+      await provider.initialize?.(mockContext)
+
+      // The provider always replaces idGenerator with react-native-uuid internally.
+      // The custom generator is NOT preserved — idGenerator is an internal concern.
+      const actualConfig = vi.mocked(initializeBKTClient).mock.calls[0][0]
+      expect(actualConfig.idGenerator).toBeDefined()
+      expect(actualConfig.idGenerator).not.toBe(customGenerator)
+
+      // The real react-native-uuid generator should be used instead
+      const id = actualConfig.idGenerator?.newId()
+      const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      expect(id).toMatch(uuidV4Regex)
+    })
+  })
+})

--- a/test/internal/provider.react.native.test.ts
+++ b/test/internal/provider.react.native.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach, suite } from 'vitest'
 
-import { BKTClient, BKTConfig, defineBKTConfig, getBKTClient, initializeBKTClient } from '@bucketeer/js-client-sdk'
+import { BKTClient, BKTConfig, getBKTClient, initializeBKTClient } from '@bucketeer/js-client-sdk'
 import {
   ClientProviderEvents,
   EvaluationContext,
   ProviderFatalError,
 } from '@openfeature/web-sdk'
-import { BucketeerReactNativeProvider, SDK_VERSION } from '../../src/main.react-native'
+import { BucketeerReactNativeProvider, SDK_VERSION, defineBKTConfigForReactNative } from '../../src/main.react-native'
 import { SOURCE_ID_OPEN_FEATURE_REACT_NATIVE } from '../../src/internal/BucketeerProvider'
 import { BKTAsyncKeyValueStore } from '../../src/internal/react_native/AsyncStorage'
 import { createReactNativeStorageFactory } from '../../src/internal/react_native/AsyncStorageFactory'
@@ -46,7 +46,7 @@ suite('BucketeerReactNativeProvider', () => {
     vi.clearAllMocks()
 
     // Create mock objects with all required properties
-    mockConfig = defineBKTConfig({
+    mockConfig = defineBKTConfigForReactNative({
       apiKey: 'test-api-key',
       apiEndpoint: 'http://test-endpoint',
       featureTag: 'test-tag',


### PR DESCRIPTION
This pull request introduces a new, safer configuration entry point for React Native users: `defineBKTConfigForReactNative`. It ensures that the `idGenerator` is always handled internally by the provider, preventing misconfiguration and improving developer experience. The documentation, example app, and tests have been updated to reflect this new approach, and internal logic has been clarified to make the provider's behavior explicit and robust.

**React Native configuration improvements:**

* Added `defineBKTConfigForReactNative`, a new function that injects a placeholder `idGenerator` and ensures the real `react-native-uuid` implementation is loaded at runtime by the provider. This prevents users from needing to supply or worry about `idGenerator` in their config. (`src/internal/react_native/defineBKTConfigForReactNative.ts`, `src/main.react-native.ts`) [[1]](diffhunk://#diff-71fba97211da9fe2608b946fef98ded72a245762d99b32130723543f7e182b74R1-R51) [[2]](diffhunk://#diff-91ca8f6ad6bd46ad59f6d5b86e1e9043553d254e43fe645527729003d5fcb601R2-R5)
* Updated the `BucketeerReactNativeProvider` to always ignore any user-supplied `idGenerator`, managing it internally and replacing it with the correct implementation during initialization. (`src/internal/react_native/BucketeerReactNativeProvider.ts`)

**Documentation and examples:**

* Revised documentation to instruct users to use `defineBKTConfigForReactNative` and clarified that `idGenerator` is always managed internally. Also explained advanced usage for those who need to use `defineBKTConfig` directly. (`docs/react-native.md`) [[1]](diffhunk://#diff-874acd12751050cf7fbdb1068d9b49fe0b5de210dd25d62b3de3cda645ba9b1bL61-R67) [[2]](diffhunk://#diff-874acd12751050cf7fbdb1068d9b49fe0b5de210dd25d62b3de3cda645ba9b1bL97-R106)
* Updated the React Native example app to use `defineBKTConfigForReactNative` instead of `defineBKTConfig`. (`examples/react_native/App.tsx`)

**Testing and validation:**

* Added comprehensive unit tests for `defineBKTConfigForReactNative`, verifying correct injection of the placeholder, error handling, and config field pass-through. (`test/internal/defineBKTConfigForReactNative.test.ts`)
* Added integration tests to confirm end-to-end provider initialization, correct replacement of `idGenerator`, and error handling when dependencies are missing. (`test/internal/integration/provider.react.native.integration.spec.ts`)
* Updated existing provider tests and test setup to use the new configuration function. (`test/internal/provider.react.native.test.ts`) [[1]](diffhunk://#diff-910da0ab33ff6109f2539492dd06852ed5864ef5ea2b471d2c94b542f676caaaL3-R9) [[2]](diffhunk://#diff-910da0ab33ff6109f2539492dd06852ed5864ef5ea2b471d2c94b542f676caaaL49-R49)